### PR TITLE
Add manual join option to Mongo adapter

### DIFF
--- a/packages/db-mongodb/ALTERNATIVES.md
+++ b/packages/db-mongodb/ALTERNATIVES.md
@@ -1,0 +1,3 @@
+# Manual Join Mode Alternatives
+
+While implementing manual join mode we considered that resolving joins in Node.js could add significant overhead. One possible alternative would be to implement a small proxy service that performs aggregation pipelines in a Mongo compatible environment and then forwards the result back to Firestore. This would keep join logic inside Mongo and avoid the need for complex client side resolution.

--- a/packages/db-mongodb/README.md
+++ b/packages/db-mongodb/README.md
@@ -20,9 +20,16 @@ import { mongooseAdapter } from '@payloadcms/db-mongodb'
 export default buildConfig({
   db: mongooseAdapter({
     url: process.env.DATABASE_URI,
+    // Enable manual join mode when using Firestore's Mongo compatibility layer
+    // or other databases that do not support $lookup pipelines
+    manualJoins: true,
   }),
   // ...rest of config
 })
 ```
+
+`manualJoins` disables `$lookup` stages in aggregation pipelines. Joins are
+resolved in Node.js instead, allowing the adapter to run against Mongo
+compatibility layers that lack full aggregation support.
 
 More detailed usage can be found in the [Payload Docs](https://payloadcms.com/docs/configuration/overview).

--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -12,6 +12,7 @@ import { buildJoinAggregation } from './utilities/buildJoinAggregation.js'
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
 import { getCollection } from './utilities/getEntity.js'
 import { getSession } from './utilities/getSession.js'
+import { resolveJoins } from './utilities/resolveJoins.js'
 import { transform } from './utilities/transform.js'
 
 export const find: Find = async function find(
@@ -153,6 +154,16 @@ export const find: Find = async function find(
     })
   } else {
     result = await Model.paginate(query, paginationOptions)
+  }
+
+  if (this.manualJoins) {
+    await resolveJoins({
+      adapter: this,
+      collectionSlug,
+      docs: result.docs as Record<string, unknown>[],
+      joins,
+      locale,
+    })
   }
 
   transform({

--- a/packages/db-mongodb/src/findOne.ts
+++ b/packages/db-mongodb/src/findOne.ts
@@ -10,6 +10,7 @@ import { buildJoinAggregation } from './utilities/buildJoinAggregation.js'
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
 import { getCollection } from './utilities/getEntity.js'
 import { getSession } from './utilities/getSession.js'
+import { resolveJoins } from './utilities/resolveJoins.js'
 import { transform } from './utilities/transform.js'
 
 export const findOne: FindOne = async function findOne(
@@ -65,6 +66,16 @@ export const findOne: FindOne = async function findOne(
   } else {
     ;(options as Record<string, unknown>).projection = projection
     doc = await Model.findOne(query, {}, options)
+  }
+
+  if (doc && this.manualJoins) {
+    await resolveJoins({
+      adapter: this,
+      collectionSlug,
+      docs: [doc] as Record<string, unknown>[],
+      joins,
+      locale,
+    })
   }
 
   if (!doc) {

--- a/packages/db-mongodb/src/index.ts
+++ b/packages/db-mongodb/src/index.ts
@@ -125,6 +125,7 @@ export interface Args {
    * NOTE: not recommended for production. This can slow down the initialization of Payload.
    */
   ensureIndexes?: boolean
+  manualJoins?: boolean
   migrationDir?: string
   /**
    * typed as any to avoid dependency
@@ -200,6 +201,7 @@ export function mongooseAdapter({
   connectOptions,
   disableIndexHints = false,
   ensureIndexes = false,
+  manualJoins = false,
   migrationDir: migrationDirArg,
   mongoMemoryServer,
   prodMigrations,
@@ -223,6 +225,7 @@ export function mongooseAdapter({
       ensureIndexes,
       // @ts-expect-error don't have globals model yet
       globals: undefined,
+      manualJoins,
       // @ts-expect-error Should not be required
       mongoMemoryServer,
       sessions: {},

--- a/packages/db-mongodb/src/queries/buildSortParam.ts
+++ b/packages/db-mongodb/src/queries/buildSortParam.ts
@@ -51,6 +51,9 @@ const relationshipSort = ({
   sortDirection: SortDirection
   versions?: boolean
 }) => {
+  if (adapter.manualJoins) {
+    return false
+  }
   let currentFields = fields
   const segments = path.split('.')
   if (segments.length < 2) {

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -12,6 +12,7 @@ import { buildJoinAggregation } from './utilities/buildJoinAggregation.js'
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
 import { getCollection } from './utilities/getEntity.js'
 import { getSession } from './utilities/getSession.js'
+import { resolveJoins } from './utilities/resolveJoins.js'
 import { transform } from './utilities/transform.js'
 
 export const queryDrafts: QueryDrafts = async function queryDrafts(
@@ -156,6 +157,16 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     })
   } else {
     result = await Model.paginate(versionQuery, paginationOptions)
+  }
+
+  if (this.manualJoins) {
+    await resolveJoins({
+      adapter: this,
+      collectionSlug,
+      docs: result.docs as Record<string, unknown>[],
+      joins,
+      locale,
+    })
   }
 
   transform({

--- a/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
+++ b/packages/db-mongodb/src/utilities/buildJoinAggregation.ts
@@ -44,6 +44,9 @@ export const buildJoinAggregation = async ({
   projection,
   versions,
 }: BuildJoinAggregationArgs): Promise<PipelineStage[] | undefined> => {
+  if (adapter.manualJoins) {
+    return
+  }
   if (
     (Object.keys(collectionConfig.joins).length === 0 &&
       collectionConfig.polymorphicJoins.length == 0) ||

--- a/packages/db-mongodb/src/utilities/resolveJoins.ts
+++ b/packages/db-mongodb/src/utilities/resolveJoins.ts
@@ -1,0 +1,126 @@
+import type { JoinQuery, SanitizedJoin } from 'payload'
+
+import type { MongooseAdapter } from '../index.js'
+
+import { buildQuery } from '../queries/buildQuery.js'
+import { buildSortParam } from '../queries/buildSortParam.js'
+
+type Args = {
+  adapter: MongooseAdapter
+  collectionSlug: string
+  docs: Record<string, unknown>[]
+  joins?: JoinQuery
+  locale?: string
+}
+
+function getByPath(doc: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((val, segment) => {
+    if (val === undefined || val === null) {
+      return undefined
+    }
+    return (val as Record<string, unknown>)[segment]
+  }, doc)
+}
+
+export async function resolveJoins({
+  adapter,
+  collectionSlug,
+  docs,
+  joins,
+  locale,
+}: Args): Promise<void> {
+  if (!joins || joins === false || docs.length === 0) {
+    return
+  }
+
+  const collectionConfig = adapter.payload.collections[collectionSlug]?.config
+  if (!collectionConfig) {
+    return
+  }
+
+  const joinMap: Record<string, { targetCollection: string } & SanitizedJoin> = {}
+
+  for (const [target, joinList] of Object.entries(collectionConfig.joins)) {
+    for (const join of joinList || []) {
+      joinMap[join.joinPath] = { ...join, targetCollection: target }
+    }
+  }
+
+  for (const [joinPath, joinQuery] of Object.entries(joins)) {
+    if (joinQuery === false) {
+      continue
+    }
+    const joinDef = joinMap[joinPath]
+    if (!joinDef) {
+      continue
+    }
+
+    const targetConfig = adapter.payload.collections[joinDef.field.collection as string]?.config
+    const JoinModel = adapter.collections[joinDef.field.collection as string]
+    if (!targetConfig || !JoinModel) {
+      continue
+    }
+
+    const parentIDs = docs.map((d) => d._id ?? d.id)
+
+    const whereQuery = await buildQuery({
+      adapter,
+      collectionSlug: joinDef.field.collection as string,
+      fields: targetConfig.flattenedFields,
+      locale,
+      where: joinQuery.where || {},
+    })
+
+    whereQuery[joinDef.field.on] = { $in: parentIDs }
+
+    const sort = buildSortParam({
+      adapter,
+      config: adapter.payload.config,
+      fields: targetConfig.flattenedFields,
+      locale,
+      sort: joinQuery.sort || joinDef.field.defaultSort || targetConfig.defaultSort,
+      timestamps: true,
+    })
+
+    const results = await JoinModel.find(whereQuery, null).sort(sort).lean()
+
+    const grouped: Record<string, Record<string, unknown>[]> = {}
+
+    for (const res of results) {
+      const parent = getByPath(res, joinDef.field.on)
+      if (!parent) {
+        continue
+      }
+      if (!grouped[parent as string]) {
+        grouped[parent as string] = []
+      }
+      grouped[parent as string].push(res)
+    }
+
+    const limit = joinQuery.limit ?? joinDef.field.defaultLimit ?? 10
+    const page = joinQuery.page ?? 1
+
+    for (const doc of docs) {
+      const id = doc._id ?? doc.id
+      const all = grouped[id] || []
+      const slice = all.slice((page - 1) * limit, (page - 1) * limit + limit)
+      const value: Record<string, unknown> = {
+        docs: slice,
+        hasNextPage: all.length > (page - 1) * limit + slice.length,
+      }
+      if (joinQuery.count) {
+        value.totalDocs = all.length
+      }
+      const segments = joinPath.split('.')
+      let ref = doc
+      for (let i = 0; i < segments.length - 1; i++) {
+        const seg = segments[i]
+        if (!ref[seg]) {
+          ref[seg] = {}
+        }
+        ref = ref[seg]
+      }
+      ref[segments[segments.length - 1]] = value
+    }
+  }
+}

--- a/test/generateDatabaseAdapter.ts
+++ b/test/generateDatabaseAdapter.ts
@@ -20,6 +20,7 @@ export const allDatabaseAdapters = {
     collation: {
       strength: 1,
     },
+    manualJoins: process.env.PAYLOAD_MANUAL_JOINS === 'true',
   })`,
   postgres: `
   import { postgresAdapter } from '@payloadcms/db-postgres'

--- a/test/manual-joins/collections/Categories.ts
+++ b/test/manual-joins/collections/Categories.ts
@@ -1,0 +1,19 @@
+import type { CollectionConfig } from 'payload'
+
+export const Categories: CollectionConfig = {
+  slug: 'categories',
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+    },
+    {
+      name: 'posts',
+      type: 'join',
+      collection: 'posts',
+      on: 'category',
+      defaultLimit: 10,
+      defaultSort: '-title',
+    },
+  ],
+}

--- a/test/manual-joins/collections/Posts.ts
+++ b/test/manual-joins/collections/Posts.ts
@@ -1,0 +1,17 @@
+import type { CollectionConfig } from 'payload'
+
+export const Posts: CollectionConfig = {
+  slug: 'posts',
+  admin: { useAsTitle: 'title' },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+    {
+      name: 'category',
+      type: 'relationship',
+      relationTo: 'categories',
+    },
+  ],
+}

--- a/test/manual-joins/config.ts
+++ b/test/manual-joins/config.ts
@@ -1,0 +1,11 @@
+import { buildConfigWithDefaults } from '../buildConfigWithDefaults.js'
+import { Categories } from './collections/Categories.js'
+import { Posts } from './collections/Posts.js'
+
+export default buildConfigWithDefaults({
+  collections: [{ slug: 'users', auth: true, fields: [] }, Posts, Categories],
+  onInit: async (payload) => {
+    const { seed } = await import('./seed.js')
+    await seed(payload)
+  },
+})

--- a/test/manual-joins/int.spec.ts
+++ b/test/manual-joins/int.spec.ts
@@ -1,0 +1,93 @@
+import type { Payload } from 'payload'
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import type { Category } from './payload-types.js'
+
+import { devUser } from '../credentials.js'
+import { initPayloadInt } from '../helpers/initPayloadInt.js'
+
+let payload: Payload
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+describe('Manual Joins', () => {
+  beforeAll(async () => {
+    process.env.PAYLOAD_MANUAL_JOINS = 'true'
+    ;({ payload } = await initPayloadInt(dirname))
+  })
+
+  afterAll(async () => {
+    await payload.destroy()
+  })
+
+  it('should populate join field using manual mode', async () => {
+    await payload.login({
+      collection: 'users',
+      data: { email: 'test@example.com', password: 'test' },
+    })
+    const [category] = await payload
+      .find({ collection: 'categories', limit: 1 })
+      .then((r) => r.docs)
+    const result = (await payload.findByID({
+      collection: 'categories',
+      id: category.id,
+      joins: { posts: { sort: '-title' } },
+    })) as Category
+    expect(result.posts.docs).toHaveLength(10)
+    expect(result.posts.docs[0].title).toBe('test 9')
+    expect(result.posts.hasNextPage).toBe(true)
+  })
+
+  it('supports custom pagination and count', async () => {
+    const [category] = await payload
+      .find({ collection: 'categories', limit: 1 })
+      .then((r) => r.docs)
+    const result = (await payload.findByID({
+      collection: 'categories',
+      id: category.id,
+      joins: { posts: { limit: 5, page: 3, count: true, sort: '-title' } },
+    })) as Category & { posts: { docs: Record<string, string>[]; totalDocs: number; hasNextPage: boolean } }
+    expect(result.posts.docs[0].title).toBe('test 12')
+    expect(result.posts.docs).toHaveLength(5)
+    expect(result.posts.totalDocs).toBe(15)
+    expect(result.posts.hasNextPage).toBe(false)
+  })
+
+  it('should resolve joins via find', async () => {
+    const result = await payload.find({
+      collection: 'categories',
+      limit: 1,
+      joins: { posts: { limit: 3 } },
+    })
+    const category = result.docs[0] as Category
+    expect(category.posts.docs).toHaveLength(3)
+    expect(typeof category.posts.hasNextPage).toBe('boolean')
+  })
+
+  it('should ignore unknown join paths', async () => {
+    const [category] = await payload
+      .find({ collection: 'categories', limit: 1 })
+      .then((r) => r.docs)
+    const result = (await payload.findByID({
+      collection: 'categories',
+      id: category.id,
+      joins: { notReal: {} },
+    })) as Category
+    expect(result.posts).toBeUndefined()
+  })
+
+  it('should return undefined when joins disabled', async () => {
+    const [category] = await payload
+      .find({ collection: 'categories', limit: 1 })
+      .then((r) => r.docs)
+    const result = (await payload.findByID({
+      collection: 'categories',
+      id: category.id,
+      joins: false,
+    })) as Category
+    expect(result.posts).toBeUndefined()
+  })
+})

--- a/test/manual-joins/payload-types.ts
+++ b/test/manual-joins/payload-types.ts
@@ -1,0 +1,11 @@
+export interface Post {
+  id: string
+  title: string
+  category: string
+}
+
+export interface Category {
+  id: string
+  name: string
+  posts: { docs: Post[] }
+}

--- a/test/manual-joins/seed.ts
+++ b/test/manual-joins/seed.ts
@@ -1,0 +1,25 @@
+import type { Payload } from 'payload'
+
+export const seed = async (payload: Payload) => {
+  await payload.create({
+    collection: 'users',
+    data: {
+      email: 'test@example.com',
+      password: 'test',
+    },
+  })
+  const category = await payload.create({
+    collection: 'categories',
+    data: { name: 'category' },
+  })
+
+  for (let i = 0; i < 15; i++) {
+    await payload.create({
+      collection: 'posts',
+      data: {
+        title: `test ${i}`,
+        category: category.id,
+      },
+    })
+  }
+}

--- a/test/manual-joins/tsconfig.eslint.json
+++ b/test/manual-joins/tsconfig.eslint.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}

--- a/test/manual-joins/tsconfig.json
+++ b/test/manual-joins/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.json"
+}


### PR DESCRIPTION
## Summary
- add manual join mode docs in Mongo adapter README
- add curly braces to grouped join resolution
- expand manual join tests for edge cases and `find`

## Testing
- `pnpm --filter @payloadcms/db-mongodb lint` *(fails: 39 warnings)*
- `PAYLOAD_MANUAL_JOINS=true pnpm test:int database` *(failed: did not finish)*
- `PAYLOAD_MANUAL_JOINS=true pnpm exec jest test/manual-joins/int.spec.ts --config=test/jest.config.js --runInBand` *(failed: did not finish)*


------
https://chatgpt.com/codex/tasks/task_b_6842891280cc8332a600512db72d6119