### PR TITLE
Fix manual join virtual field sort

### DIFF
--- a/packages/db-mongodb/src/find.ts
+++ b/packages/db-mongodb/src/find.ts
@@ -12,6 +12,7 @@ import { buildJoinAggregation } from './utilities/buildJoinAggregation.js'
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
 import { getCollection } from './utilities/getEntity.js'
 import { getSession } from './utilities/getSession.js'
+import { manualSort } from './utilities/manualSort.js'
 import { resolveJoins } from './utilities/resolveJoins.js'
 import { transform } from './utilities/transform.js'
 
@@ -172,6 +173,14 @@ export const find: Find = async function find(
     fields: collectionConfig.fields,
     operation: 'read',
   })
+
+  if (this.manualJoins) {
+    manualSort({
+      docs: result.docs as Record<string, unknown>[],
+      fields: collectionConfig.flattenedFields,
+      sort: sortArg,
+    })
+  }
 
   return result
 }

--- a/packages/db-mongodb/src/queryDrafts.ts
+++ b/packages/db-mongodb/src/queryDrafts.ts
@@ -12,6 +12,7 @@ import { buildJoinAggregation } from './utilities/buildJoinAggregation.js'
 import { buildProjectionFromSelect } from './utilities/buildProjectionFromSelect.js'
 import { getCollection } from './utilities/getEntity.js'
 import { getSession } from './utilities/getSession.js'
+import { manualSort } from './utilities/manualSort.js'
 import { resolveJoins } from './utilities/resolveJoins.js'
 import { transform } from './utilities/transform.js'
 
@@ -175,6 +176,14 @@ export const queryDrafts: QueryDrafts = async function queryDrafts(
     fields: buildVersionCollectionFields(this.payload.config, collectionConfig),
     operation: 'read',
   })
+
+  if (this.manualJoins) {
+    manualSort({
+      docs: result.docs as Record<string, unknown>[],
+      fields,
+      sort: sortArg,
+    })
+  }
 
   for (let i = 0; i < result.docs.length; i++) {
     const id = result.docs[i].parent

--- a/packages/db-mongodb/src/utilities/manualSort.ts
+++ b/packages/db-mongodb/src/utilities/manualSort.ts
@@ -1,0 +1,56 @@
+export type SortArg = string | string[] | undefined
+
+import type { FlattenedField } from 'payload'
+
+function getByPath(doc: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((val, segment) => {
+    if (val === undefined || val === null) {
+      return undefined
+    }
+    return (val as Record<string, unknown>)[segment]
+  }, doc)
+}
+
+export function manualSort({
+  docs,
+  fields,
+  sort,
+}: {
+  docs: Record<string, unknown>[]
+  fields: FlattenedField[]
+  sort: SortArg
+}): void {
+  if (!sort) {return}
+
+  const fieldMap = new Map<string, string>()
+  for (const field of fields) {
+    if ('virtual' in field && typeof field.virtual === 'string') {
+      fieldMap.set(field.virtual, field.name)
+    }
+  }
+
+  const sortArray = Array.isArray(sort) ? sort : [sort]
+  const sortItems = sortArray.map((item) => {
+    let direction: 'asc' | 'desc' = 'asc'
+    let prop = item
+    if (item.startsWith('-')) {
+      direction = 'desc'
+      prop = item.substring(1)
+    }
+    const path = fieldMap.get(prop) || prop
+    return { direction, path }
+  })
+
+  docs.sort((a, b) => {
+    for (const { direction, path } of sortItems) {
+      const av = getByPath(a, path) as number | string
+      const bv = getByPath(b, path) as number | string
+      if (av === bv) {continue}
+      if (av === undefined || av === null) {return direction === 'asc' ? -1 : 1}
+      if (bv === undefined || bv === null) {return direction === 'asc' ? 1 : -1}
+      if (av > bv) {return direction === 'asc' ? 1 : -1}
+      if (av < bv) {return direction === 'asc' ? -1 : 1}
+    }
+    return 0
+  })
+}


### PR DESCRIPTION
## Summary
- add manualSort utility to order documents by fields resolved after joins
- use manualSort in MongoDB find and queryDrafts when manual join mode is enabled

## Testing
- `pnpm test:int database -t='should allow to query by a virtual field with reference'` *(fails: cannot connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_b_6843a2ee32ac8332a99d7693f6d899d3